### PR TITLE
Fix webservices manifest

### DIFF
--- a/src/plugins/webservices/weblinks/weblinks.xml
+++ b/src/plugins/webservices/weblinks/weblinks.xml
@@ -2,17 +2,16 @@
 <extension version="3.1" type="plugin" group="webservices" method="upgrade">
 	<name>plg_webservices_weblinks</name>
 	<author>Joomla! Project</author>
-	<creationDate>August 2017</creationDate>
-	<copyright>(C) 2005 - 2019 Open Source Matters. All rights reserved.</copyright>
+	<creationDate>##DATE##</creationDate>
+	<copyright>(C) 2005 - ##YEAR## Open Source Matters. All rights reserved.</copyright>
 	<license>GNU General Public License version 2 or later; see LICENSE.txt</license>
 	<authorEmail>admin@joomla.org</authorEmail>
 	<authorUrl>www.joomla.org</authorUrl>
-	<version>4.0.0</version>
+	<version>##VERSION##</version>
 	<description>PLG_WEBSERVICES_WEBLINKS_XML_DESCRIPTION</description>
 	<namespace path="src">Joomla\Plugin\WebServices\Weblinks</namespace>
 	<files>
-		<folder plugin="weblinks">services</folder>
-		<folder>src</folder>
+		##FILES##
 	</files>
 	<languages folder="language">
 		##LANGUAGE_FILES##


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

This pr is a continuation of https://github.com/joomla-extensions/weblinks/pull/580, It fixes the manifest file for webservices.
previously, when installing webservices using the `vendor/bin/robo build`, it would leave out the language strings and it had hard coded old date and version.

before this pr:
![image](https://github.com/user-attachments/assets/dc3cb934-6290-48a5-873f-742d3ba7b2d4)

after this pr:
![image](https://github.com/user-attachments/assets/2252a5ee-095c-40ed-af33-3edea5d46246)


### Testing Instructions



### Expected result



### Actual result



### Documentation Changes Required

