### PR TITLE
Add QuickIcon plugin

### DIFF
--- a/src/administrator/components/com_weblinks/src/Controller/WeblinksController.php
+++ b/src/administrator/components/com_weblinks/src/Controller/WeblinksController.php
@@ -57,7 +57,7 @@ class WeblinksController extends AdminController
         }
 
         $responseData = [
-            'amount' => $amount
+            'amount' => $amount,
         ];
 
         echo new JsonResponse($responseData);

--- a/src/administrator/components/com_weblinks/src/Controller/WeblinksController.php
+++ b/src/administrator/components/com_weblinks/src/Controller/WeblinksController.php
@@ -14,6 +14,7 @@ namespace Joomla\Component\Weblinks\Administrator\Controller;
 \defined('_JEXEC') or die;
 // phpcs:enable PSR1.Files.SideEffects
 use Joomla\CMS\MVC\Controller\AdminController;
+use Joomla\CMS\Response\JsonResponse;
 
 /**
  * Weblinks list controller class.
@@ -36,5 +37,29 @@ class WeblinksController extends AdminController
     public function getModel($name = 'Weblink', $prefix = 'Administrator', $config = ['ignore_request' => true])
     {
         return parent::getModel($name, $prefix, $config);
+    }
+    /**
+     * Method to get the JSON-encoded amount of published articles
+     *
+     * @return  void
+     *
+     * @since   5.0.0
+     */
+    public function getQuickiconContent()
+    {
+        $model = $this->getModel('Weblinks');
+
+        $model->setState('filter.published', 1);
+
+        $amount = 0;
+        if ($model) {
+            $amount = (int) $model->getTotal();
+        }
+
+        $responseData = [
+            'amount' => $amount
+        ];
+
+        echo new JsonResponse($responseData);
     }
 }

--- a/src/administrator/manifests/packages/pkg_weblinks.xml
+++ b/src/administrator/manifests/packages/pkg_weblinks.xml
@@ -23,6 +23,7 @@
 		<file type="plugin" id="weblinks" group="system">plg_system_weblinks.zip</file>
 		<file type="plugin" id="weblinks" group="editors-xtd">plg_editors-xtd_weblink.zip</file>
 		<file type="plugin" id="weblinks" group="webservices">plg_webservices_weblinks.zip</file>
+		<file type="plugin" id="weblinks" group="quickicon">plg_quickicon_weblinks.zip</file>
 	</files>
 	<languages folder="language">
 		<language tag="en-GB">en-GB/pkg_weblinks.sys.ini</language>

--- a/src/plugins/quickicon/weblinks/language/en-GB/plg_quickicon_weblinks.ini
+++ b/src/plugins/quickicon/weblinks/language/en-GB/plg_quickicon_weblinks.ini
@@ -1,0 +1,7 @@
+; Joomla! Project
+; Copyright (C) 2005 - 2025 Open Source Matters. All rights reserved.
+; License GNU General Public License version 2 or later; see LICENSE.txt, see LICENSE.php
+; Note : All ini files need to be saved as UTF-8
+
+PLG_QUICKICON_WEBLINKS_TITLE="Weblinks"
+PLG_QUICKICON_WEBLINKS_SHOW_COUNT="Show Count"

--- a/src/plugins/quickicon/weblinks/language/en-GB/plg_quickicon_weblinks.sys.ini
+++ b/src/plugins/quickicon/weblinks/language/en-GB/plg_quickicon_weblinks.sys.ini
@@ -1,0 +1,7 @@
+; Joomla! Project
+; Copyright (C) 2005 - 2025 Open Source Matters. All rights reserved.
+; License GNU General Public License version 2 or later; see LICENSE.txt, see LICENSE.php
+; Note : All ini files need to be saved as UTF-8
+
+PLG_QUICKICON_WEBLINKS="Quick Icon - Weblinks"
+PLG_QUICKICON_WEBLINKS_XML_DESCRIPTION="Displays a Quick Icon for the Weblinks component."

--- a/src/plugins/quickicon/weblinks/services/provider.php
+++ b/src/plugins/quickicon/weblinks/services/provider.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * @package     Joomla.Plugin
+ * @subpackage  Webservices.weblinks
+ *
+ * @copyright   (C) 2023 Open Source Matters, Inc. <https://www.joomla.org>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+\defined('_JEXEC') or die;
+
+use Joomla\CMS\Extension\PluginInterface;
+use Joomla\CMS\Factory;
+use Joomla\CMS\Plugin\PluginHelper;
+use Joomla\DI\Container;
+use Joomla\DI\ServiceProviderInterface;
+use Joomla\Event\DispatcherInterface;
+use Joomla\Plugin\Quickicon\Weblinks\Extension\Weblinks;
+
+return new class () implements ServiceProviderInterface {
+    /**
+     * Registers the service provider with a DI container.
+     *
+     * @param   Container  $container  The DI container.
+     *
+     * @return  void
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function register(Container $container): void
+    {
+        $container->set(
+            PluginInterface::class,
+            function (Container $container) {
+                $dispatcher = $container->get(DispatcherInterface::class);
+                $plugin     = new Weblinks(
+                    $dispatcher,
+                    (array) PluginHelper::getPlugin('quickicon', 'weblinks')
+                );
+                $plugin->setApplication(Factory::getApplication());
+
+                return $plugin;
+            }
+        );
+    }
+};

--- a/src/plugins/quickicon/weblinks/services/provider.php
+++ b/src/plugins/quickicon/weblinks/services/provider.php
@@ -2,9 +2,9 @@
 
 /**
  * @package     Joomla.Plugin
- * @subpackage  Webservices.weblinks
+ * @subpackage  Quickicon.weblinks
  *
- * @copyright   (C) 2023 Open Source Matters, Inc. <https://www.joomla.org>
+ * @copyright   (C) 2025 Open Source Matters, Inc. <https://www.joomla.org>
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 

--- a/src/plugins/quickicon/weblinks/src/Extension/Weblinks.php
+++ b/src/plugins/quickicon/weblinks/src/Extension/Weblinks.php
@@ -7,13 +7,12 @@
 
 namespace Joomla\Plugin\Quickicon\Weblinks\Extension;
 
+use Joomla\CMS\Language\Text;
 use Joomla\CMS\Plugin\CMSPlugin;
 use Joomla\Event\SubscriberInterface;
-use Joomla\CMS\Language\Text;
 use Joomla\Module\Quickicon\Administrator\Event\QuickIconsEvent;
 
-
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 /**
  * Weblinks Quick Icon plugin.
@@ -66,15 +65,15 @@ final class Weblinks extends CMSPlugin implements SubscriberInterface
 
         $iconDefinition = [
             [
-                'image'  => 'icon-link',
-                'link'   => 'index.php?option=com_weblinks',
-                'linkadd'   => 'index.php?option=com_weblinks&task=weblink.add',
-                'text'   => Text::_('PLG_QUICKICON_WEBLINKS_TITLE'),
-                'id'     => 'PLG_QUICKICON_WEBLINKS'
+                'image'   => 'icon-link',
+                'link'    => 'index.php?option=com_weblinks',
+                'linkadd' => 'index.php?option=com_weblinks&task=weblink.add',
+                'text'    => Text::_('PLG_QUICKICON_WEBLINKS_TITLE'),
+                'id'      => 'PLG_QUICKICON_WEBLINKS',
             ],
         ];
 
-        if($this->params->get('show_count', 1)) {
+        if ($this->params->get('show_count', 1)) {
             $iconDefinition[0]['ajaxurl'] = 'index.php?option=com_weblinks&task=weblinks.getQuickiconContent&format=json';
         } else {
             unset($iconDefinition[0]['ajaxurl']);

--- a/src/plugins/quickicon/weblinks/src/Extension/Weblinks.php
+++ b/src/plugins/quickicon/weblinks/src/Extension/Weblinks.php
@@ -7,12 +7,14 @@
 
 namespace Joomla\Plugin\Quickicon\Weblinks\Extension;
 
+// phpcs:disable PSR1.Files.SideEffects
+\defined('_JEXEC') or die;
+// phpcs:enable PSR1.Files.SideEffects
+
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Plugin\CMSPlugin;
 use Joomla\Event\SubscriberInterface;
 use Joomla\Module\Quickicon\Administrator\Event\QuickIconsEvent;
-
-\defined('_JEXEC') or die;
 
 /**
  * Weblinks Quick Icon plugin.

--- a/src/plugins/quickicon/weblinks/src/Extension/Weblinks.php
+++ b/src/plugins/quickicon/weblinks/src/Extension/Weblinks.php
@@ -1,0 +1,90 @@
+<?php
+
+/**
+ * @copyright   Copyright (C) 2025. All rights reserved
+ * @license     GNU/GPL Version 2 or later - http://www.gnu.org/licenses/gpl-2.0.html
+ */
+
+namespace Joomla\Plugin\Quickicon\Weblinks\Extension;
+
+use Joomla\CMS\Plugin\CMSPlugin;
+use Joomla\Event\SubscriberInterface;
+use Joomla\CMS\Language\Text;
+use Joomla\Module\Quickicon\Administrator\Event\QuickIconsEvent;
+
+
+defined('_JEXEC') or die;
+
+/**
+ * Weblinks Quick Icon plugin.
+ *
+ * @since       1.0.0
+ */
+final class Weblinks extends CMSPlugin implements SubscriberInterface
+{
+    /**
+     * Load the language file on instantiation.
+     *
+     * @var    boolean
+     * @since  3.1
+     */
+    protected $autoloadLanguage = true;
+
+    /**
+     * Returns an array of events this subscriber will listen to.
+     *
+     * @return  array
+     *
+     * @since   4.3.0
+     */
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            'onGetIcons' => 'onGetIcons',
+        ];
+    }
+
+    /**
+     * Event to get the quick icons.
+     *
+     * @param   string  $context  The context of the event.
+     *
+     * @return  array|null  An array of icon definition arrays, or null if not applicable.
+     *
+     * @since   1.0.0
+     */
+    public function onGetIcons(QuickIconsEvent $event): void
+    {
+        $context = $event->getContext();
+
+        if (
+            $context !== $this->params->get('context', 'mod_quickicon')
+            || !$this->getApplication()->getIdentity()->authorise('core.manage', 'com_weblinks')
+        ) {
+            return;
+        }
+
+        $iconDefinition = [
+            [
+                'image'  => 'icon-link',
+                'link'   => 'index.php?option=com_weblinks',
+                'linkadd'   => 'index.php?option=com_weblinks&task=weblink.add',
+                'text'   => Text::_('PLG_QUICKICON_WEBLINKS_TITLE'),
+                'id'     => 'PLG_QUICKICON_WEBLINKS'
+            ],
+        ];
+
+        if($this->params->get('show_count', 1)) {
+            $iconDefinition[0]['ajaxurl'] = 'index.php?option=com_weblinks&task=weblinks.getQuickiconContent&format=json';
+        } else {
+            unset($iconDefinition[0]['ajaxurl']);
+        }
+
+        // Add the icon to the result array
+        $result = $event->getArgument('result', []);
+
+        $result[] = $iconDefinition;
+
+        $event->setArgument('result', $result);
+    }
+}

--- a/src/plugins/quickicon/weblinks/weblinks.xml
+++ b/src/plugins/quickicon/weblinks/weblinks.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<extension version="3.9" type="plugin" group="quickicon" method="upgrade">
+    <name>plg_quickicon_weblinks</name>
+    <author>Joomla! Project</author>
+	<creationDate>##DATE##</creationDate>
+	<copyright>(C) 2005 - ##YEAR## Open Source Matters. All rights reserved.</copyright>
+	<license>GNU General Public License version 2 or later; see	LICENSE.txt</license>
+	<authorEmail>admin@joomla.org</authorEmail>
+	<authorUrl>www.joomla.org</authorUrl>
+	<version>##VERSION##</version>
+    <description>PLG_QUICKICON_WEBLINKS_XML_DESCRIPTION</description>
+	<namespace path="src">Joomla\Plugin\Quickicon\Weblinks</namespace>
+    <files>
+		##FILES##
+	</files>
+	<languages folder="language">
+		##LANGUAGE_FILES##
+	</languages>
+    <config>
+		<fields name="params">
+			<fieldset name="basic">
+				<field
+					name="show_count"
+					type="radio"
+					label="PLG_QUICKICON_WEBLINKS_SHOW_COUNT"
+					layout="joomla.form.field.radio.switcher"
+					default="0"
+					filter="boolean"
+					>
+					<option value="0">JNO</option>
+					<option value="1">JYES</option>
+				</field>
+			</fieldset>
+		</fields>
+	</config>
+</extension>

--- a/tests/cypress/integration/administrator/components/com_weblinks/CheckPackage.cy.js
+++ b/tests/cypress/integration/administrator/components/com_weblinks/CheckPackage.cy.js
@@ -77,4 +77,18 @@ describe('Test that the weblinks extension package', () => {
         cy.get('td').eq(7).should('contain', 'N/A'); // Folder column
       });
   });
+
+  it('has Quickicon plugin installed', () => {
+    // Check if the row with "Quick Icon - Weblinks" exists
+    cy.get('#manageList tbody tr') // Target the table rows
+      .contains('th', 'Quick Icon - Weblinks') // Check the <th> in the row
+      .parents('tr') // Navigate to the parent row
+      .should('exist') // Confirm the row exists
+      // Verify other cells in the same row
+      .within(() => {
+        cy.get('td').eq(2).should('contain', 'Site'); // Location column
+        cy.get('td').eq(3).should('contain', 'Plugin'); // Type column
+        cy.get('td').eq(7).should('contain', 'quickicon'); // Folder column
+      });
+  });
 })

--- a/tests/cypress/integration/plugins/quickicon/weblinks/Quickicon.cy.js
+++ b/tests/cypress/integration/plugins/quickicon/weblinks/Quickicon.cy.js
@@ -1,0 +1,81 @@
+
+describe('Test in backend that the Quickicon', () => {
+  const quickIconAnchorId = 'PLG_QUICKICON_WEBLINKS';
+  const moduleData = {
+    title: 'Test Weblinks Quick Icons Module',
+    module: 'mod_quickicon',
+    position: 'cpanel',
+    published: 1,
+    client_id: 1,
+    showtitle: 0,
+  };
+
+  beforeEach(() => {
+    cy.doAdministratorLogin();
+    // Enable the Quick Icon - Weblinks plugin
+    cy.db_enableExtension('1', 'plg_quickicon_weblinks');
+  });
+
+  afterEach(() => {
+    // Disable the plugin
+    cy.db_enableExtension('0', 'plg_quickicon_weblinks');
+  });
+
+  it('shows the weblinks icon with add and without counter if disabled', () => {
+    // Set the show_count parameter is set to 0
+    cy.db_updateExtensionParameter('show_count', '0', 'plg_quickicon_weblinks');
+
+    // Create a new Quick Icons module
+    cy.db_createModule(moduleData).then(() => {
+      // Go to Home Dashboard
+      cy.visit('/administrator/index.php');
+
+      // Check for the Weblinks Quick Icon
+      cy.get(`a#${quickIconAnchorId}`).should('be.visible')
+
+      // Check for the "add" link associated with the quick icon group
+      cy.get(`a#${quickIconAnchorId}`)
+        .parents('.quickicon-group')
+        .find('.quickicon-linkadd a[href*="option=com_weblinks&task=weblink.add"]')
+        .should('be.visible');
+
+      // Check that the amount element should not exist
+      cy.get(`a#${quickIconAnchorId} .quickicon-amount[data-url]`)
+        .should('not.exist');
+    });
+  });
+
+  it('shows the weblinks icon with add and counter if enabled', () => {
+    // Set the show_count parameter is set to 1
+    cy.db_updateExtensionParameter('show_count', '1', 'plg_quickicon_weblinks');
+
+    // Create a new Quick Icons module
+    cy.db_createModule(moduleData).then((moduleId) => {
+      // Go to Home Dashboard
+      cy.visit('/administrator/index.php');
+
+      // Check for the Weblinks Quick Icon
+      cy.get(`a#${quickIconAnchorId}`).should('be.visible');
+
+      // Check for the "add" link associated with the quick icon group
+      cy.get(`a#${quickIconAnchorId}`)
+        .parents('.quickicon-group')
+        .find('.quickicon-linkadd a[href*="option=com_weblinks&task=weblink.add"]')
+        .should('be.visible');
+
+      // Check that the amount element exists and shows a number
+      cy.get(`a#${quickIconAnchorId} .quickicon-amount[data-url]`)
+        .should('exist')
+        .and('be.visible')
+        .should(($el) => {
+          // Get the text and remove all LRM characters (U+200E) for a cleaner check
+          const text = $el.text().replace(/\u200E/g, '').trim();
+          expect(text).not.to.be.empty;
+          // Spinner should be gone, replaced by the count
+          expect($el.find('span.icon-spinner').length).to.equal(0);
+          // Check if the cleaned text consists only of digits
+          expect(text).to.match(/^\d+$/);
+        });
+    });
+  });
+});


### PR DESCRIPTION
Pull Request for Issue #2  .

### Summary of Changes
This pr adds QuickIcon plugin for weblinks, with the ability to add and see the count of published weblinks


### Testing Instructions
1. Build the plugin using robo `vendor/bin/robo` and install it
2. Activate it from the `Plugins` in the dashboard (you can also choose to show the count for published weblinks)
3. Create a QuickIcon module

### Expected result
Weblinks should appear when creating a QuickIcon module and activating the Quickicon plugin for weblinks

![image](https://github.com/user-attachments/assets/36b5d1b3-fc1b-4a04-8927-c17901097b76)


### Actual result
N/A


### Documentation Changes Required

