### PR TITLE
Automatic unpublish plugin

### DIFF
--- a/src/administrator/manifests/packages/pkg_weblinks.xml
+++ b/src/administrator/manifests/packages/pkg_weblinks.xml
@@ -25,6 +25,7 @@
 		<file type="plugin" id="weblinks" group="editors-xtd">plg_editors-xtd_weblink.zip</file>
 		<file type="plugin" id="weblinks" group="webservices">plg_webservices_weblinks.zip</file>
 		<file type="plugin" id="weblinks" group="quickicon">plg_quickicon_weblinks.zip</file>
+		<file type="plugin" id="weblinks" group="task">plg_task_weblinks.zip</file>
 	</files>
 	<languages folder="language">
 		<language tag="en-GB">en-GB/pkg_weblinks.sys.ini</language>

--- a/src/plugins/task/weblinks/language/en-GB/plg_task_weblinks.ini
+++ b/src/plugins/task/weblinks/language/en-GB/plg_task_weblinks.ini
@@ -1,0 +1,2 @@
+PLG_TASK_WEBLINKS_UNPUBLISH_TITLE="Unpublish Weblinks"
+PLG_TASK_WEBLINKS_UNPUBLISH_DESC="Unpublishes weblinks that have passed their publish down date."

--- a/src/plugins/task/weblinks/language/en-GB/plg_task_weblinks.sys.ini
+++ b/src/plugins/task/weblinks/language/en-GB/plg_task_weblinks.sys.ini
@@ -1,0 +1,2 @@
+PLG_TASK_WEBLINKS="Task - Weblinks"
+PLG_TASK_WEBLINKS_XML_DESCRIPTION="This plugin unpublishes weblinks after their expiration date."

--- a/src/plugins/task/weblinks/services/provider.php
+++ b/src/plugins/task/weblinks/services/provider.php
@@ -1,0 +1,28 @@
+<?php
+
+use Joomla\CMS\Extension\PluginInterface;
+use Joomla\CMS\Plugin\PluginHelper;
+use Joomla\Database\DatabaseInterface;
+use Joomla\DI\Container;
+use Joomla\DI\ServiceProviderInterface;
+use Joomla\Event\DispatcherInterface;
+use Joomla\Plugin\Task\Weblinks\Extension\Weblinks;
+
+return new class () implements ServiceProviderInterface {
+    public function register(Container $container): void
+    {
+        $container->set(
+            PluginInterface::class,
+            function (Container $container) {
+                $dispatcher = $container->get(DispatcherInterface::class);
+                $plugin = new Weblinks(
+                    $dispatcher,
+                    (array) PluginHelper::getPlugin('task', 'weblinks')
+                );
+
+                $plugin->setDatabase($container->get(DatabaseInterface::class));
+                return $plugin;
+            }
+        );
+    }
+};

--- a/src/plugins/task/weblinks/src/Extension/Weblinks.php
+++ b/src/plugins/task/weblinks/src/Extension/Weblinks.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Joomla\Plugin\Task\Weblinks\Extension;
+
+// phpcs:disable PSR1.Files.SideEffects
+\defined('_JEXEC') or die;
+// phpcs:enable PSR1.Files.SideEffects
+
+use Joomla\CMS\Date\Date;
+use Joomla\CMS\Plugin\CMSPlugin;
+use Joomla\Component\Scheduler\Administrator\Event\ExecuteTaskEvent;
+use Joomla\Component\Scheduler\Administrator\Task\Status;
+use Joomla\Component\Scheduler\Administrator\Traits\TaskPluginTrait;
+use Joomla\Event\SubscriberInterface;
+use Joomla\Database\DatabaseAwareTrait;
+use Joomla\Database\DatabaseAwareInterface;
+
+/**
+ * Unpublish task scheduler for com_weblinks.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+final class Weblinks extends CMSPlugin implements SubscriberInterface, DatabaseAwareInterface
+{
+    use DatabaseAwareTrait;
+    use TaskPluginTrait;
+
+    /**
+     * @var string[]
+     * @since __DEPLOY_VERSION__
+     */
+    private const TASKS_MAP = [
+        'weblinks.unpublish' => [
+            'langConstPrefix' => 'PLG_TASK_WEBLINKS_UNPUBLISH',
+            'method'          => 'unpublish',
+        ],
+    ];
+
+    /**
+     * Load the language file on instantiation.
+     *
+     * @var    boolean
+     * @since  __DEPLOY_VERSION__
+     */
+    protected $autoloadLanguage = true;
+
+    /**
+     * @inheritDoc
+     *
+     * @return string[]
+     *
+     * @since  __DEPLOY_VERSION__
+     */
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            'onTaskOptionsList'    => 'advertiseRoutines',
+            'onExecuteTask'        => 'standardRoutineHandler',
+            'onContentPrepareForm' => 'enhanceTaskItemForm',
+        ];
+    }
+
+    /**
+     * @param   ExecuteTaskEvent  $event  The execute task event
+     *
+     * @return  integer
+     *
+     * @since  __DEPLOY_VERSION__
+     */
+    public function unpublish(ExecuteTaskEvent $event): int
+    {
+        $db    = $this->getDatabase();
+        $query = $db->getQuery(true)
+            ->update($db->quoteName('#__weblinks'))
+            ->set($db->quoteName('state') . ' = 0')
+            ->where($db->quoteName('state') . ' = 1')
+            ->where($db->quoteName('publish_down') . ' < ' . $db->quote((new Date())->toSql()))
+            ->where($db->quoteName('publish_down') . ' <> ' . $db->quote($db->getNullDate()));
+
+        try {
+            $db->setQuery($query)->execute();
+        } catch (\Exception $e) {
+            $this->logTask($e->getMessage(), 'error');
+            return Status::KNOCKOUT;
+        }
+
+        return Status::OK;
+    }
+}

--- a/src/plugins/task/weblinks/weblinks.xml
+++ b/src/plugins/task/weblinks/weblinks.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<extension type="plugin" group="task" method="upgrade">
+    <name>plg_task_weblinks</name>
+    <author>Joomla! Project</author>
+	<creationDate>##DATE##</creationDate>
+	<copyright>(C) 2005 - ##YEAR## Open Source Matters. All rights reserved.</copyright>
+	<license>GNU General Public License version 2 or later; see	LICENSE.txt</license>
+	<authorEmail>admin@joomla.org</authorEmail>
+	<authorUrl>www.joomla.org</authorUrl>
+	<version>##VERSION##</version>
+    <description>PLG_TASK_WEBLINKS_XML_DESCRIPTION</description>
+    <namespace path="src">Joomla\Plugin\Task\Weblinks</namespace>
+    <files>
+		##FILES##
+    </files>
+    <languages folder="language">
+		##LANGUAGE_FILES##
+	</languages>
+</extension>


### PR DESCRIPTION
Pull Request for Issue #10 .

### Summary of Changes
This PR creates a task plugin to unpublish weblinks when the "Finish Publishing" date is due.


### Testing Instructions
1.  Make a zip file for the plugin using `vendor/bin/robo` build
2. Install the plugin the activate it
3. Go to `Scheduled Tasks` and create a task for unpublish


### Expected result
Automaticlly unpublish weblinks when the "Finish Publishing" date is due.


### Actual result
N/A


### Documentation Changes Required

