### PR TITLE
add system test for GET endpoint with filter

### DIFF
--- a/tests/cypress/integration/api/com_weblinks/Categories.cy.js
+++ b/tests/cypress/integration/api/com_weblinks/Categories.cy.js
@@ -67,3 +67,39 @@ describe('Test that weblinks categories API endpoint', () => {
     cy.db_enableExtension('0', 'plg_webservices_weblinks');
   });
 });
+
+describe('Test that weblinks categories API endpoint filters', () => {
+  afterEach(() => {
+    cy.task('queryDB', "DELETE FROM #__categories WHERE title LIKE '%automated test category%' AND extension = 'com_weblinks'");
+  });
+
+  it('can filter by search term', () => {
+    cy.db_enableExtension('1', 'plg_webservices_weblinks');
+    cy.db_createCategory({ title: 'automated test category', extension: 'com_weblinks' });
+    cy.db_createCategory({ title: 'another category', extension: 'com_weblinks' });
+
+    cy.api_get('/weblinks/categories?filter[search]=automated')
+      .then((response) => {
+        cy.wrap(response).its('body').its('data').should('have.length', 1);
+        cy.wrap(response).its('body').its('data.0').its('attributes')
+          .its('title')
+          .should('include', 'automated test category');
+      });
+    cy.db_enableExtension('0', 'plg_webservices_weblinks');
+  });
+
+  it('can paginate the categories', () => {
+    cy.db_enableExtension('1', 'plg_webservices_weblinks');
+    cy.db_createCategory({ title: 'automated test category 1', extension: 'com_weblinks' });
+    cy.db_createCategory({ title: 'automated test category 2', extension: 'com_weblinks' });
+
+    cy.api_get('/weblinks/categories?page[limit]=1&page[offset]=1')
+      .then((response) => {
+        cy.wrap(response).its('body').its('data').should('have.length', 1);
+        cy.wrap(response).its('body').its('data.0').its('attributes')
+          .its('title')
+          .should('include', 'automated test category 2');
+      });
+    cy.db_enableExtension('0', 'plg_webservices_weblinks');
+  });
+});

--- a/tests/cypress/integration/api/com_weblinks/FieldGroups.cy.js
+++ b/tests/cypress/integration/api/com_weblinks/FieldGroups.cy.js
@@ -60,4 +60,19 @@ describe('Test that weblinks field groups API endpoint', () => {
       .then((response) => cy.wrap(response).its('status').should('eq', 204));
     cy.db_enableExtension('0', 'plg_webservices_weblinks');
   });
+
+  it('can filter and paginate the field groups', () => {
+    cy.db_enableExtension('1', 'plg_webservices_weblinks');
+    cy.db_createFieldGroup({ title: 'automated test field group 1', context: 'com_weblinks.weblink' });
+    cy.db_createFieldGroup({ title: 'automated test field group 2', context: 'com_weblinks.weblink' });
+
+    cy.api_get('/fields/groups/weblinks?page[limit]=1&page[offset]=1')
+      .then((response) => {
+        cy.wrap(response).its('body').its('data').should('have.length', 1);
+        cy.wrap(response).its('body').its('data.0').its('attributes')
+          .its('title')
+          .should('include', 'automated test field group 2');
+      });
+    cy.db_enableExtension('0', 'plg_webservices_weblinks');
+  });
 });

--- a/tests/cypress/integration/api/com_weblinks/Fields.cy.js
+++ b/tests/cypress/integration/api/com_weblinks/Fields.cy.js
@@ -60,4 +60,20 @@ describe('Test that weblinks fields API endpoint', () => {
       .then((response) => cy.wrap(response).its('status').should('eq', 204));
     cy.db_enableExtension('0', 'plg_webservices_weblinks');
   });
+
+
+  it('can filter and paginate the fields', () => {
+    cy.db_enableExtension('1', 'plg_webservices_weblinks');
+    cy.db_createField({ title: 'automated test field 1', context: 'com_weblinks.weblink' });
+    cy.db_createField({ title: 'automated test field 2', context: 'com_weblinks.weblink' });
+
+    cy.api_get('/fields/weblinks?page[limit]=1&page[offset]=1')
+      .then((response) => {
+        cy.wrap(response).its('body').its('data').should('have.length', 1);
+        cy.wrap(response).its('body').its('data.0').its('attributes')
+          .its('title')
+          .should('include', 'automated test field 2');
+      });
+    cy.db_enableExtension('0', 'plg_webservices_weblinks');
+  });
 });

--- a/tests/cypress/integration/api/com_weblinks/Weblinks.cy.js
+++ b/tests/cypress/integration/api/com_weblinks/Weblinks.cy.js
@@ -57,3 +57,87 @@ describe('Test that weblinks API endpoint', () => {
     cy.db_enableExtension('0', 'plg_webservices_weblinks');
   });
 });
+
+describe('Test that weblinks API endpoint filters', () => {
+  afterEach(() => {
+    cy.task('queryDB', "DELETE FROM #__weblinks WHERE title LIKE '%automated test weblink%'");
+    cy.task('queryDB', "DELETE FROM #__categories WHERE title LIKE '%automated test category%' AND extension = 'com_weblinks'");
+  });
+
+  it('can filter by category', () => {
+    cy.db_enableExtension('1', 'plg_webservices_weblinks');
+    cy.db_createCategory({ title: 'automated test category', extension: 'com_weblinks' })
+      .then((categoryId) => {
+        cy.db_createWeblink({ title: 'automated test weblink', catid: categoryId });
+        cy.db_createWeblink({ title: 'automated test weblink 2' });
+
+        cy.api_get(`/weblinks?filter[category]=${categoryId}`)
+          .then((response) => {
+            cy.wrap(response).its('body').its('data').should('have.length', 1);
+            cy.wrap(response).its('body').its('data.0').its('attributes')
+              .its('title')
+              .should('include', 'automated test weblink');
+          });
+      });
+    cy.db_enableExtension('0', 'plg_webservices_weblinks');
+  });
+
+  it('can filter by search term', () => {
+    cy.db_enableExtension('1', 'plg_webservices_weblinks');
+    cy.db_createWeblink({ title: 'automated test weblink' });
+    cy.db_createWeblink({ title: 'another weblink' });
+
+    cy.api_get('/weblinks?filter[search]=automated')
+      .then((response) => {
+        cy.wrap(response).its('body').its('data').should('have.length', 1);
+        cy.wrap(response).its('body').its('data.0').its('attributes')
+          .its('title')
+          .should('include', 'automated test weblink');
+      });
+    cy.db_enableExtension('0', 'plg_webservices_weblinks');
+  });
+
+  it('can filter by state', () => {
+    cy.db_enableExtension('1', 'plg_webservices_weblinks');
+    cy.db_createWeblink({ title: 'automated test weblink', state: 1 });
+    cy.db_createWeblink({ title: 'automated test weblink 2', state: 0 });
+
+    cy.api_get('/weblinks?filter[state]=1')
+      .then((response) => {
+        cy.wrap(response).its('body').its('data').should('have.length', 1);
+        cy.wrap(response).its('body').its('data.0').its('attributes')
+          .its('title')
+          .should('include', 'automated test weblink');
+      });
+    cy.db_enableExtension('0', 'plg_webservices_weblinks');
+  });
+
+  it('can sort the weblinks', () => {
+    cy.db_enableExtension('1', 'plg_webservices_weblinks');
+    cy.db_createWeblink({ title: 'automated test weblink a' });
+    cy.db_createWeblink({ title: 'automated test weblink b' });
+
+    cy.api_get('/weblinks?list[ordering]=title&list[direction]=DESC')
+      .then((response) => {
+        cy.wrap(response).its('body').its('data.0').its('attributes')
+          .its('title')
+          .should('include', 'automated test weblink b');
+      });
+    cy.db_enableExtension('0', 'plg_webservices_weblinks');
+  });
+
+  it('can paginate the weblinks', () => {
+    cy.db_enableExtension('1', 'plg_webservices_weblinks');
+    cy.db_createWeblink({ title: 'automated test weblink 1' });
+    cy.db_createWeblink({ title: 'automated test weblink 2' });
+
+    cy.api_get('/weblinks?page[limit]=1&page[offset]=1')
+      .then((response) => {
+        cy.wrap(response).its('body').its('data').should('have.length', 1);
+        cy.wrap(response).its('body').its('data.0').its('attributes')
+          .its('title')
+          .should('include', 'automated test weblink 2');
+      });
+    cy.db_enableExtension('0', 'plg_webservices_weblinks');
+  });
+});


### PR DESCRIPTION
Pull Request for Issue #20  .

### Summary of Changes
This PR adds Cypress tests for GET weblinks endpoints (weblinks, categories, weblinks custom fields and field groups)


### Testing Instructions
Run the tests using `npx cypress run` or `npx cypress open`


### Expected result



### Actual result



### Documentation Changes Required

