### PR TITLE
Add the option to choose multiple categories in the module

### DIFF
--- a/src/components/com_weblinks/src/Model/CategoryModel.php
+++ b/src/components/com_weblinks/src/Model/CategoryModel.php
@@ -147,21 +147,19 @@ class CategoryModel extends ListModel
             ->from($db->quoteName('#__weblinks') . ' AS a')
             ->whereIn($db->quoteName('a.access'), $viewLevels);
 
-        // Filter by category.
+        // Filter by category
         if ($categoryId = $this->getState('category.id')) {
-            // Group by subcategory
-            if ($this->getState('category.group', 0)) {
-                $query->select('c.title AS category_title')
-                    ->where('c.parent_id = :parent_id')
-                    ->bind(':parent_id', $categoryId, ParameterType::INTEGER)
-                    ->join('LEFT', '#__categories AS c ON c.id = a.catid')
-                    ->whereIn($db->quoteName('c.access'), $viewLevels);
+            // Handle array of category IDs
+            if (\is_array($categoryId)) {
+                $query->whereIn($db->quoteName('a.catid'), $categoryId);
             } else {
                 $query->where('a.catid = :catid')
-                    ->bind(':catid', $categoryId, ParameterType::INTEGER)
-                    ->join('LEFT', '#__categories AS c ON c.id = a.catid')
-                    ->whereIn($db->quoteName('c.access'), $viewLevels);
+                    ->bind(':catid', $categoryId, ParameterType::INTEGER);
             }
+
+            // Join categories table
+            $query->join('LEFT', '#__categories AS c ON c.id = a.catid')
+                ->whereIn($db->quoteName('c.access'), $viewLevels);
 
             // Filter by published category
             $cpublished = $this->getState('filter.c.published');

--- a/src/modules/mod_weblinks/mod_weblinks.xml
+++ b/src/modules/mod_weblinks/mod_weblinks.xml
@@ -28,6 +28,10 @@
 					label="JCATEGORY"
 					extension="com_weblinks"
 					required="true"
+					multiple="true"
+					filter="intarray"
+					class="multipleCategories"
+					layout="joomla.form.field.list-fancy-select"
 				/>
 
 				<field

--- a/src/modules/mod_weblinks/src/Helper/WeblinksHelper.php
+++ b/src/modules/mod_weblinks/src/Helper/WeblinksHelper.php
@@ -39,12 +39,42 @@ class WeblinksHelper
      **/
     public function getWeblinks($params, $app)
     {
+        $catidArray = (array) $params->get('catid', []);
+
         // @var \Joomla\Component\Weblinks\Site\Model\CategoryModel $model
         if ($params->get('groupby')) {
-            return $this->getCategoryTree($params->get('catid', 1), $params, $app, 0, $params->get('maxLevel', -1)) ?? [];
+            // Get all category objects for the selected IDs
+            $allSelectedCategories = [];
+            $categoriesFactory     = Factory::getApplication()->bootComponent('com_weblinks')->getCategory();
+            foreach ($catidArray as $id) {
+                $category = $categoriesFactory->get($id);
+                if ($category) {
+                    $allSelectedCategories[$id] = $category;
+                }
+            }
+
+            // Filter to find only the root selections
+            $rootCatIds = [];
+            foreach ($allSelectedCategories as $id => $category) {
+                $parentId = $category->getParent()->id;
+                if (!isset($allSelectedCategories[$parentId])) {
+                    $rootCatIds[] = $id;
+                }
+            }
+
+            if (empty($rootCatIds) && !empty($catidArray)) {
+                $rootCatIds = $catidArray;
+            }
+
+            //  build trees only for the root categories
+            $trees = [];
+            foreach ($rootCatIds as $id) {
+                $trees[] = $this->getCategoryTree($id, $params, $app, 0, $params->get('maxLevel', -1));
+            }
+            return $trees;
         }
 
-        return $this->getCategoryWeblinks($params->get('catid', 1), $params, $app);
+        return $this->getCategoryWeblinks($catidArray, $params, $app);
     }
 
     /**
@@ -95,8 +125,11 @@ class WeblinksHelper
      *
      * @since   __DEPLOY_VERSION__
      */
-    private function getCategoryWeblinks(int $catid, Registry $params, CMSApplicationInterface $app): array
+    private function getCategoryWeblinks(int|array $catid, Registry $params, CMSApplicationInterface $app): array
     {
+        if (!\is_array($catid)) {
+            $catid = [$catid];
+        }
         $model = $app->bootComponent('com_weblinks')->getMVCFactory()
             ->createModel('Category', 'Site', ['ignore_request' => true]);
 

--- a/src/modules/mod_weblinks/tmpl/default.php
+++ b/src/modules/mod_weblinks/tmpl/default.php
@@ -15,8 +15,9 @@
 use Joomla\CMS\Helper\ModuleHelper;
 
 if ($params->get('groupby', 0)) {
-    $categoryNode = $list;
-    require ModuleHelper::getLayoutPath('mod_weblinks', $params->get('layout', 'default') . '_category');
+    foreach ($list as $categoryNode) {
+        require ModuleHelper::getLayoutPath('mod_weblinks', $params->get('layout', 'default') . '_category');
+    }
 } else {
     $weblinks = $list;
     require ModuleHelper::getLayoutPath('mod_weblinks', $params->get('layout', 'default') . '_items');

--- a/src/modules/mod_weblinks/tmpl/default_category.php
+++ b/src/modules/mod_weblinks/tmpl/default_category.php
@@ -24,9 +24,24 @@ if (!$categoryNode) {
 
 $hasWeblinks = !empty($categoryNode->weblinks);
 
-// check if the current category has any weblinks.
-// We only create a div and apply logic if it does.
-if ($hasWeblinks) {
+$selectedCategories = (array) $params->get('catid', []);
+
+// check if the "Show Parent Category" option is turned off
+$hideParent = !$params->get('show_parent_category', 0);
+
+// a category is a root if it's selected and its parent is not
+$parent = $categoryNode->category->getParent();
+
+$isCurrentSelected = in_array($categoryNode->category->id, $selectedCategories);
+$isParentSelected = in_array($parent->id, $selectedCategories);
+
+$isRootCategory = $isCurrentSelected && !$isParentSelected;
+
+// We should skip rendering the content of this category if it's the root and the "hide parent" option is on
+$skipContent = $isRootCategory && $hideParent;
+
+// Render the category content only if it has weblinks and we are not skipping it
+if ($hasWeblinks && !$skipContent) {
     $cssClass = 'weblinks-category';
 
     // Apply padding only if this is NOT the first category.


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
This PR adds the ability to choose multiple categories when creating a module, This feature is available in many components in Joomla but was never introduced to the Weblinks Module, and it also supports `Group By Subcategories` and nested categories

This is how it looks after this PR

<img width="1333" height="216" alt="image" src="https://github.com/user-attachments/assets/b390ae59-dfdf-4fff-8b60-ab671079a1fd" />

<img width="1201" height="177" alt="image" src="https://github.com/user-attachments/assets/a8518f87-e871-482b-99d0-2893a8693728" />

with `Group By Subcategories`  ON
<img width="1352" height="263" alt="image" src="https://github.com/user-attachments/assets/f47fd300-ed7b-433a-a3f5-d24f6b054103" />

<img width="873" height="425" alt="image" src="https://github.com/user-attachments/assets/ac399388-2832-45b5-8bf8-065e4efa2bea" />


### Testing Instructions
Create a module with multiple categories

### Expected result
A way to display multiple categories of weblinks in the frontend with the weblinks module

### Actual result
Only being able to display one category per module


### Documentation Changes Required