### PR TITLE
Fix uninstalling of plg_editors-xtd_weblink

### DIFF
--- a/src/administrator/manifests/packages/pkg_weblinks.xml
+++ b/src/administrator/manifests/packages/pkg_weblinks.xml
@@ -22,7 +22,7 @@
 		<file type="plugin" id="weblinks" group="finder">plg_finder_weblinks.zip</file>
 		<file type="plugin" id="weblinks" group="search">plg_search_weblinks.zip</file>
 		<file type="plugin" id="weblinks" group="system">plg_system_weblinks.zip</file>
-		<file type="plugin" id="weblinks" group="editors-xtd">plg_editors-xtd_weblink.zip</file>
+		<file type="plugin" id="weblink" group="editors-xtd">plg_editors-xtd_weblink.zip</file>
 		<file type="plugin" id="weblinks" group="webservices">plg_webservices_weblinks.zip</file>
 		<file type="plugin" id="weblinks" group="quickicon">plg_quickicon_weblinks.zip</file>
 		<file type="plugin" id="weblinks" group="task">plg_task_weblinks.zip</file>


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
<img width="772" height="127" alt="image" src="https://github.com/user-attachments/assets/a94f1313-ba97-4ee4-afbe-f0add98aa66c" />
Fixes this issue when uninstalling `Web Links Extension Package` 


### Testing Instructions
1. Build and install the extension
2. Try to uninstall the `Web Links Extension Package`


### Expected result
Uninstalling without any issues


### Actual result
Uninstalling gives error for `plg_editors-xtd_weblink`


### Documentation Changes Required

